### PR TITLE
Add tox as test harness

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source = django_backup
+branch = True
+
+[report]
+omit = *tests*,test_project

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 *.egg-info
 dist
+.tox
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+sudo: false
+env:
+  matrix:
+    - TOXENV=py27-dj17-postgres
+    - TOXENV=py27-dj17-mysql
+    - TOXENV=py27-dj18-postgres
+    - TOXENV=py27-dj18-mysql
+install:
+  - pip install tox
+script: tox

--- a/django_backup/tests.py
+++ b/django_backup/tests.py
@@ -1,0 +1,28 @@
+import tempfile
+import shutil
+import os
+
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class DbBackupTests(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_generation(self):
+        with self.settings(BACKUP_LOCAL_DIRECTORY=self.tmpdir):
+            call_command('backup')
+            files = os.listdir(self.tmpdir)
+            self.assertEqual(1, len(files))
+            self.assertRegexpMatches(files[0], r'backup_\d{8}-\d{6}\.sql')
+
+    def test_compressed_generation(self):
+        with self.settings(BACKUP_LOCAL_DIRECTORY=self.tmpdir):
+            call_command('backup', compress=True)
+            files = os.listdir(self.tmpdir)
+            self.assertEqual(1, len(files))
+            self.assertRegexpMatches(files[0], r'backup_\d{8}-\d{6}\.sql\.gz')

--- a/test_project/core/settings.py
+++ b/test_project/core/settings.py
@@ -17,14 +17,19 @@ PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': '', # Or path to database file if using sqlite3.
+        'NAME': 'django_backup',         # Or path to database file if using sqlite3.
         'USER': '',                      # Not used with sqlite3.
         'PASSWORD': '',                  # Not used with sqlite3.
         'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
         'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
     }
 }
+
+if os.environ['DBENGINE'] == 'mysql':
+    DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
+else:
+    DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'
+
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -167,6 +172,7 @@ BACKUP_FTP_USERNAME = None
 BACKUP_FTP_PASSWORD = None
 BACKUP_FTP_DIRECTORY = None
 
+TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist=
+    py{27}-dj{17,18}-{mysql,postgres}
+
+[testenv]
+deps=
+    coverage<4.0.0
+    git+https://github.com/andybak/Pysftp.git#egg=pysftp
+    postgres: psycopg2
+    mysql: mysqlclient
+    dj17: Django==1.7.8
+    dj18: Django==1.8.1
+setenv=
+    postgres: DBENGINE=postgresql
+    mysql: DBENGINE=mysql
+basepython=
+    py27: python2.7
+commands=
+    coverage run test_project/manage.py test django_backup
+    coverage report


### PR DESCRIPTION
This way we should be able to test effectively against all currently
support Django and Python versions as soon as we have enough coverage
for both commands.

This commit only includes a demo test-case for the backup command.
